### PR TITLE
Add zcia (compressed cia) file install support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "externals/zstd"]
+	path = externals/zstd
+	url = https://github.com/facebook/zstd.git

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ VERSION_MICRO := $(word 3, $(VERSION_PARTS))
 TARGET		:=	$(notdir $(CURDIR))
 BUILD		:=	build
 SOURCES		:=	source/core source/core/data source/core/task source/core/ui \
-				source/fbi source/fbi/action source/fbi/task \
+				source/core/z3ds source/fbi source/fbi/action source/fbi/task \
 				source/libs/quirc source/libs/stb_image
 DATA		:=
 INCLUDES	:=
@@ -59,6 +59,10 @@ UNIQUE_ID := 0xF8001
 BANNER_AUDIO := $(TOPDIR)/meta/audio_3ds.wav
 BANNER_IMAGE := $(TOPDIR)/meta/banner_3ds.cgfx
 
+ZSTD_DIR  		:= $(CURDIR)/externals/zstd
+ZSTD_OUT  		?= $(CURDIR)/$(BUILD)/zstd
+ZSTD_SEEK_DIR   := $(ZSTD_DIR)/contrib/seekable_format
+
 #---------------------------------------------------------------------------------
 # options for code generation
 #---------------------------------------------------------------------------------
@@ -75,7 +79,7 @@ CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions -std=gnu++11
 ASFLAGS	:=	-g $(ARCH)
 LDFLAGS	=	-specs=3dsx.specs -g $(ARCH) -Wl,-Map,$(notdir $*.map)
 
-LIBS	:= -lcurl -lmbedtls -lmbedx509 -lmbedcrypto -lcitro3d -lctru -lm -lz -ljansson
+LIBS	:= -lcurl -lmbedtls -lmbedx509 -lmbedcrypto -lcitro3d -lctru -lm -lz -ljansson -lzstd-seekable -lzstd 
 
 #---------------------------------------------------------------------------------
 # list of directories containing libraries, this must be the top level containing
@@ -107,6 +111,9 @@ PICAFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.v.pica)))
 SHLISTFILES	:=	$(foreach dir,$(SOURCES),$(notdir $(wildcard $(dir)/*.shlist)))
 GFXFILES	:=	$(foreach dir,$(GRAPHICS),$(notdir $(wildcard $(dir)/*.t3s)))
 BINFILES	:=	$(foreach dir,$(DATA),$(notdir $(wildcard $(dir)/*.*)))
+
+ZSTD_SEEK_OBJS := $(addprefix $(ZSTD_OUT)/seek/,\
+                     zstdseek_compress.o zstdseek_decompress.o)
 
 #---------------------------------------------------------------------------------
 # use CXX for linking C++ projects, CC for standard C
@@ -149,9 +156,12 @@ export HFILES	:=	$(PICAFILES:.v.pica=_shbin.h) $(SHLISTFILES:.shlist=_shbin.h) \
 
 export INCLUDE	:=	$(foreach dir,$(INCLUDES),-I$(CURDIR)/$(dir)) \
 			$(foreach dir,$(LIBDIRS),-I$(dir)/include) \
-			-I$(CURDIR)/$(BUILD)
+			-I$(CURDIR)/$(BUILD) \
+			-I$(ZSTD_SEEK_DIR) \
+			-I$(ZSTD_DIR)/lib/common
 
-export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib)
+export LIBPATHS	:=	$(foreach dir,$(LIBDIRS),-L$(dir)/lib) \
+			-L$(ZSTD_OUT)
 
 export _3DSXDEPS	:=	$(if $(NO_SMDH),,$(OUTPUT).smdh)
 
@@ -176,11 +186,27 @@ ifneq ($(ROMFS),)
 	export _3DSXFLAGS += --romfs=$(CURDIR)/$(ROMFS)
 endif
 
-.PHONY: all clean
+.PHONY: all clean zstd-seekable
 
 #---------------------------------------------------------------------------------
-all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES)
+
+all: $(BUILD) $(GFXBUILD) $(DEPSDIR) $(ROMFS_T3XFILES) $(T3XHFILES) zstd-seekable
 	@$(MAKE) --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
+
+#---------------------------------------------------------------------------------
+# Build the Zstandard seekable static library
+#---------------------------------------------------------------------------------
+
+$(ZSTD_OUT)/seek/%.o: $(ZSTD_SEEK_DIR)/%.c
+	@mkdir -p $(dir $@)
+	$(CC) $(CFLAGS) $(INCLUDE) -c $< -o $@
+
+$(ZSTD_OUT)/libzstd-seekable.a: $(ZSTD_SEEK_OBJS)
+	@$(AR) rcs $@ $^
+
+zstd-seekable: $(ZSTD_OUT)/libzstd-seekable.a
+
+#---------------------------------------------------------------------------------
 
 $(BUILD):
 	@mkdir -p $@

--- a/source/core/core.h
+++ b/source/core/core.h
@@ -3,6 +3,7 @@
 #include "data/data.h"
 #include "task/task.h"
 #include "ui/ui.h"
+#include "z3ds/z3ds.h"
 
 #include "clipboard.h"
 #include "error.h"

--- a/source/core/data/cia.c
+++ b/source/core/data/cia.c
@@ -1,9 +1,12 @@
+#include "memory.h"
+
 #include <3ds.h>
 
 #include "cia.h"
 #include "smdh.h"
 #include "tmd.h"
 #include "../error.h"
+#include "../z3ds/z3ds.h"
 
 Result cia_get_title_id(u64* titleId, u8* cia, size_t size) {
     if(cia == NULL) {
@@ -26,25 +29,34 @@ Result cia_get_title_id(u64* titleId, u8* cia, size_t size) {
     return tmd_get_title_id(titleId, &cia[offset], size - offset);
 }
 
-Result cia_file_get_smdh(SMDH* smdh, Handle handle) {
+Result cia_file_get_smdh(SMDH* smdh, Handle handle, void* z3ds_file) {
     Result res = 0;
 
     if(smdh != NULL) {
-        u32 bytesRead = 0;
 
-        u32 header[8];
-        if(R_SUCCEEDED(res = FSFILE_Read(handle, &bytesRead, 0, header, sizeof(header))) && bytesRead == sizeof(header)) {
-            u32 headerSize = (header[0] + 0x3F) & ~0x3F;
-            u32 certSize = (header[2] + 0x3F) & ~0x3F;
-            u32 ticketSize = (header[3] + 0x3F) & ~0x3F;
-            u32 tmdSize = (header[4] + 0x3F) & ~0x3F;
-            u32 metaSize = (header[5] + 0x3F) & ~0x3F;
-            u64 contentSize = ((header[6] | ((u64) header[7] << 32)) + 0x3F) & ~0x3F;
+        if (z3ds_file) {
+            Z3DS_Metadata_Item item = Z3DS_GetMetadataItem(z3ds_file, "smdh");
+            if (!item.found || item.size != sizeof(SMDH)) {
+                return R_APP_BAD_DATA;
+            }
+            memcpy(smdh, item.value, sizeof(SMDH));
+        } else {
+            u32 bytesRead = 0;
 
-            if(metaSize >= 0x3AC0) {
-                res = FSFILE_Read(handle, &bytesRead, headerSize + certSize + ticketSize + tmdSize + contentSize + 0x400, smdh, sizeof(SMDH));
-            } else {
-                res = R_APP_BAD_DATA;
+            u32 header[8];
+            if(R_SUCCEEDED(res = FSFILE_Read(handle, &bytesRead, 0, header, sizeof(header))) && bytesRead == sizeof(header)) {
+                u32 headerSize = (header[0] + 0x3F) & ~0x3F;
+                u32 certSize = (header[2] + 0x3F) & ~0x3F;
+                u32 ticketSize = (header[3] + 0x3F) & ~0x3F;
+                u32 tmdSize = (header[4] + 0x3F) & ~0x3F;
+                u32 metaSize = (header[5] + 0x3F) & ~0x3F;
+                u64 contentSize = ((header[6] | ((u64) header[7] << 32)) + 0x3F) & ~0x3F;
+
+                if(metaSize >= 0x3AC0) {
+                    res = FSFILE_Read(handle, &bytesRead, headerSize + certSize + ticketSize + tmdSize + contentSize + 0x400, smdh, sizeof(SMDH));
+                } else {
+                    res = R_APP_BAD_DATA;
+                }
             }
         }
     } else {

--- a/source/core/data/cia.h
+++ b/source/core/data/cia.h
@@ -3,4 +3,4 @@
 typedef struct SMDH_s SMDH;
 
 Result cia_get_title_id(u64* titleId, u8* cia, size_t size);
-Result cia_file_get_smdh(SMDH* smdh, Handle handle);
+Result cia_file_get_smdh(SMDH* smdh, Handle handle, void* z3ds_file);

--- a/source/core/fs.c
+++ b/source/core/fs.c
@@ -209,7 +209,8 @@ bool fs_filter_cias(void* data, const char* name, u32 attributes) {
     }
 
     size_t len = strlen(name);
-    return len >= 4 && strncasecmp(name + len - 4, ".cia", 4) == 0;
+    return (len >= 4 && strncasecmp(name + len - 4, ".cia", 4) == 0) || 
+            (len >= 5 && strncasecmp(name + len - 5, ".zcia", 5) == 0);
 }
 
 bool fs_filter_tickets(void* data, const char* name, u32 attributes) {

--- a/source/core/task/dataop.c
+++ b/source/core/task/dataop.c
@@ -47,7 +47,7 @@ static Result task_data_op_copy(data_op_data* data, u32 index) {
     } else {
         u32 srcHandle = 0;
         if(R_SUCCEEDED(res = data->openSrc(data->data, index, &srcHandle))) {
-            if(R_SUCCEEDED(res = data->getSrcSize(data->data, srcHandle, &data->currTotal))) {
+            if(R_SUCCEEDED(res = data->getSrcSize(data->data, index, srcHandle, &data->currTotal))) {
                 if(data->currTotal == 0) {
                     if(data->copyEmpty) {
                         u32 dstHandle = 0;
@@ -73,7 +73,7 @@ static Result task_data_op_copy(data_op_data* data, u32 index) {
                             }
 
                             u32 bytesRead = 0;
-                            if(R_FAILED(res = data->readSrc(data->data, srcHandle, &bytesRead, buffer, data->currProcessed, data->bufferSize))) {
+                            if(R_FAILED(res = data->readSrc(data->data, index, srcHandle, &bytesRead, buffer, data->currProcessed, data->bufferSize))) {
                                 break;
                             }
 

--- a/source/core/task/dataop.h
+++ b/source/core/task/dataop.h
@@ -43,8 +43,8 @@ typedef struct data_op_data_s {
     Result (*openSrc)(void* data, u32 index, u32* handle);
     Result (*closeSrc)(void* data, u32 index, bool succeeded, u32 handle);
 
-    Result (*getSrcSize)(void* data, u32 handle, u64* size);
-    Result (*readSrc)(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size);
+    Result (*getSrcSize)(void* data, u32 index, u32 handle, u64* size);
+    Result (*readSrc)(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size);
 
     // Download
     Result (*getSrcUrl)(void* data, u32 index, char* url, size_t maxSize);

--- a/source/core/z3ds/z3ds.c
+++ b/source/core/z3ds/z3ds.c
@@ -1,0 +1,187 @@
+
+#include <malloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "z3ds.h"
+#include "z3ds_impl.h"
+
+#include "../error.h"
+
+static int zstd_read(void* opaque, void* buffer, size_t n) {
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)opaque;
+    u32 bytesRead = 0;
+    Result res = FSFILE_Read(file->handle, &bytesRead, file->current_pos, buffer, n);
+    if (R_FAILED(res) || bytesRead != n) {
+        return -1;
+    }
+    file->current_pos += n;
+    return 0;
+}
+
+static int zstd_seek(void* opaque, long long offset, int origin) {
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)opaque;
+    Z3DSFileHeader* header = (Z3DSFileHeader*)file->header;
+
+    s64 start = 0;
+    switch (origin) {
+    case SEEK_SET:
+        start = (s64)(header->metadata_size + header->header_size);
+        break;
+    case SEEK_CUR:
+        start = (s64)file->current_pos;
+        break;
+    case SEEK_END:
+        start = (s64)((header->compressed_size + header->metadata_size) + header->header_size);
+        break;
+    default:
+        break;
+    }
+    s64 new_pos = start + offset;
+    if (new_pos < 0)
+        return -1;
+    file->current_pos = new_pos;
+    return 0;
+}
+
+bool Z3DS_IsFile(Handle handle, const void *underlying_magic, size_t underlying_magic_size)
+{
+    Z3DSFileHeader header;
+    size_t msize = (underlying_magic_size > 4) ? 4 : underlying_magic_size;
+    u32 bytesRead = 0;
+    return R_SUCCEEDED(FSFILE_Read(handle, &bytesRead, 0, &header, sizeof(Z3DSFileHeader))) && 
+            bytesRead == sizeof(Z3DSFileHeader) &&
+            memcmp(header.magic, Z3DS_MAGIC, 4) == 0 &&
+            header.version == Z3DS_VERSION &&
+            memcmp(header.underlying_magic, underlying_magic, msize) == 0;
+}
+
+Z3DS_FILE *Z3DS_Create(Handle handle)
+{
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)malloc(sizeof(Z3DS_FILE_IMPL));
+    if (!file) {
+        return file;
+    }
+
+    file->handle = handle;
+    file->header = (Z3DSFileHeader*)malloc(sizeof(Z3DSFileHeader));
+    Z3DSFileHeader* header = file->header;
+    if (!file->header) {
+        Z3DS_Free((Z3DS_FILE*)file, false);
+        return NULL;
+    }
+
+    u32 bytesRead = 0;
+    if (
+        R_FAILED(FSFILE_Read(file->handle, &bytesRead, 0, header, sizeof(Z3DSFileHeader))) || bytesRead != sizeof(Z3DSFileHeader) ||
+        memcmp(header->magic, Z3DS_MAGIC, 4) != 0 ||
+        header->version != Z3DS_VERSION
+    ) {
+        Z3DS_Free((Z3DS_FILE*)file, false);
+        return NULL;
+    }
+
+    file->metadata = NULL;
+    if (header->metadata_size) {
+        file->metadata = (u8*)malloc(header->metadata_size);
+        if (!file->metadata || R_FAILED(FSFILE_Read(file->handle, &bytesRead, header->header_size, file->metadata, header->metadata_size)) || bytesRead != header->metadata_size) {
+            Z3DS_Free((Z3DS_FILE*)file, false);
+            return NULL;
+        }
+    }
+
+    ZSTD_seekable_customFile custom_file;
+    custom_file.opaque = file;
+    custom_file.read = zstd_read;
+    custom_file.seek = zstd_seek;
+
+    file->seekable = ZSTD_seekable_create();
+    size_t init_result = ZSTD_seekable_initAdvanced(file->seekable, custom_file);
+    if (ZSTD_isError(init_result)) {
+        Z3DS_Free((Z3DS_FILE*)file, false);
+        return NULL;
+    }
+
+    return (Z3DS_FILE*)file;
+}
+
+Result Z3DS_GetUncompressedSize(Z3DS_FILE *file_user, u64* sizeOut)
+{
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)file_user;
+    if (!file) {
+        return R_APP_INVALID_ARGUMENT;
+    }
+
+    *sizeOut = file->header->uncompressed_size;
+    return 0;
+}
+
+Result Z3DS_Read(Z3DS_FILE *file_user, u32 *bytesRead, u64 offset, void *buffer, u32 size)
+{
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)file_user;
+    if (!file) {
+        return R_APP_INVALID_ARGUMENT;
+    }
+
+    size_t result = ZSTD_seekable_decompress(file->seekable, buffer, size, offset);
+    if (ZSTD_isError(result)) {
+        return R_APP_BAD_DATA;
+    }
+    *bytesRead = (u32)result;
+    return 0;
+}
+
+void Z3DS_Free(Z3DS_FILE *file_user, bool closeHandle)
+{
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)file_user;
+    if (file) {
+        if (closeHandle) {
+            FSFILE_Close(file->handle);
+        }
+        if (file->seekable) ZSTD_seekable_free(file->seekable);
+        if (file->header) free(file->header);
+        if (file->metadata) free(file->metadata);
+        free(file);
+    }
+}
+
+Z3DS_Metadata_Item Z3DS_GetMetadataItem(Z3DS_FILE *file_user, const char *metadata_name)
+{
+    Z3DS_FILE_IMPL* file = (Z3DS_FILE_IMPL*)file_user;
+    Z3DS_Metadata_Item ret = {0};
+    
+    if (!file->metadata || file->metadata[0] != Z3DS_METADATA_VERSION) {
+        return ret;
+    }
+
+    size_t md_name_len = strlen(metadata_name);
+
+    u8* start = file->metadata + 1;
+    u8* end = file->metadata + file->header->metadata_size;
+
+    while (start < end) {
+        Z3DSMetadataItemHeader it_header;
+        memcpy(&it_header, start, sizeof(Z3DSMetadataItemHeader));
+        start += sizeof(Z3DSMetadataItemHeader);
+
+        if (it_header.type == Z3DS_MD_TYPE_END) {
+            break;
+        }
+        if (it_header.type != Z3DS_MD_TYPE_BINARY) {
+            start += (u32)it_header.name_len + (u32)it_header.data_len;
+            continue;
+        }
+
+        u8* name = start;
+        u8* value = start + it_header.name_len;
+        start += (u32)it_header.name_len + (u32)it_header.data_len;
+        if (it_header.name_len == md_name_len && memcmp(name, metadata_name, md_name_len) == 0) {
+            ret.found = true;
+            ret.value = value;
+            ret.size = it_header.data_len;
+            break;
+        }
+    }
+    return ret;
+}

--- a/source/core/z3ds/z3ds.h
+++ b/source/core/z3ds/z3ds.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <3ds.h>
+#include <zstd_seekable.h>
+
+typedef void Z3DS_FILE;
+
+bool Z3DS_IsFile(Handle handle, const void* underlying_magic, size_t underlying_magic_size);
+
+Z3DS_FILE* Z3DS_Create(Handle handle);
+Result Z3DS_GetUncompressedSize(Z3DS_FILE* file, u64* sizeOut);
+Result Z3DS_Read(Z3DS_FILE* file, u32* bytesRead, u64 offset, void* buffer, u32 size);
+void Z3DS_Free(Z3DS_FILE* file, bool closeHandle);
+
+typedef struct {
+    bool found;
+
+    const u8* value; // Valid until Z3DS_Free is called
+    u32 size;
+} Z3DS_Metadata_Item;
+
+Z3DS_Metadata_Item Z3DS_GetMetadataItem(Z3DS_FILE* file, const char* metadata_name);

--- a/source/core/z3ds/z3ds_impl.h
+++ b/source/core/z3ds/z3ds_impl.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <3ds.h>
+
+typedef struct {
+    u8 magic[4];
+    u8 underlying_magic[4];
+    u8 version;
+    u8 reserved;
+    u16 header_size;
+    u32 metadata_size;
+    u64 compressed_size;
+    u64 uncompressed_size;
+} Z3DSFileHeader;
+
+enum {
+    Z3DS_MD_TYPE_END = 0,
+    Z3DS_MD_TYPE_BINARY = 1,
+};
+
+typedef struct {
+    u8 type;
+    u8 name_len;
+    u16 data_len;
+} Z3DSMetadataItemHeader;
+
+#define Z3DS_MAGIC "Z3DS"
+#define Z3DS_VERSION 1
+#define Z3DS_METADATA_VERSION 1
+
+typedef struct {
+    Z3DSFileHeader* header;
+    u8* metadata;
+    ZSTD_seekable* seekable;
+
+    Handle handle;
+
+    u64 current_pos;
+} Z3DS_FILE_IMPL;

--- a/source/fbi/action/erasetwlsave.c
+++ b/source/fbi/action/erasetwlsave.c
@@ -36,7 +36,7 @@ static Result action_erase_twl_save_close_src(void* data, u32 index, bool succee
     return 0;
 }
 
-static Result action_erase_twl_save_get_src_size(void* data, u32 handle, u64* size) {
+static Result action_erase_twl_save_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     Result res = 0;
 
     u32 saveSize = 0;
@@ -47,7 +47,7 @@ static Result action_erase_twl_save_get_src_size(void* data, u32 handle, u64* si
     return res;
 }
 
-static Result action_erase_twl_save_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result action_erase_twl_save_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     memset(buffer, 0, size);
     *bytesRead = size;
 

--- a/source/fbi/action/exporttwlsave.c
+++ b/source/fbi/action/exporttwlsave.c
@@ -35,7 +35,7 @@ static Result action_export_twl_save_close_src(void* data, u32 index, bool succe
     return spi_deinit_card();
 }
 
-static Result action_export_twl_save_get_src_size(void* data, u32 handle, u64* size) {
+static Result action_export_twl_save_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     Result res = 0;
 
     u32 saveSize = 0;
@@ -46,7 +46,7 @@ static Result action_export_twl_save_get_src_size(void* data, u32 handle, u64* s
     return res;
 }
 
-static Result action_export_twl_save_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result action_export_twl_save_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     return spi_read_save(bytesRead, buffer, (u32) offset, size);
 }
 

--- a/source/fbi/action/importtwlsave.c
+++ b/source/fbi/action/importtwlsave.c
@@ -54,11 +54,11 @@ static Result action_import_twl_save_close_src(void* data, u32 index, bool succe
     return FSFILE_Close(handle);
 }
 
-static Result action_import_twl_save_get_src_size(void* data, u32 handle, u64* size) {
+static Result action_import_twl_save_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     return FSFILE_GetSize(handle, size);
 }
 
-static Result action_import_twl_save_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result action_import_twl_save_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     return FSFILE_Read(handle, bytesRead, offset, buffer, size);
 }
 

--- a/source/fbi/action/installcias.c
+++ b/source/fbi/action/installcias.c
@@ -59,6 +59,10 @@ static Result action_install_cias_open_src(void* data, u32 index, u32* handle) {
     if(fsPath != NULL) {
         res = FSUSER_OpenFile(handle, info->archive, *fsPath, FS_OPEN_READ, 0);
 
+        if (info->ciaInfo.isZ3DS && R_SUCCEEDED(res)) {
+            *handle = (Handle)Z3DS_Create(*handle);
+        }
+
         fs_free_path_utf8(fsPath);
     } else {
         res = R_APP_OUT_OF_MEMORY;
@@ -74,7 +78,13 @@ static Result action_install_cias_close_src(void* data, u32 index, bool succeede
 
     Result res = 0;
 
-    if(R_SUCCEEDED(res = FSFILE_Close(handle)) && installData->delete && succeeded) {
+    if (info->ciaInfo.isZ3DS) {
+        Z3DS_Free((Z3DS_FILE*)handle, true);
+    } else {
+        res = FSFILE_Close(handle);
+    }
+
+    if(R_SUCCEEDED(res) && installData->delete && succeeded) {
         FS_Path* fsPath = fs_make_path_utf8(info->path);
         if(fsPath != NULL) {
             if(R_SUCCEEDED(FSUSER_DeleteFile(info->archive, *fsPath))) {
@@ -101,12 +111,28 @@ static Result action_install_cias_close_src(void* data, u32 index, bool succeede
     return res;
 }
 
-static Result action_install_cias_get_src_size(void* data, u32 handle, u64* size) {
-    return FSFILE_GetSize(handle, size);
+static Result action_install_cias_get_src_size(void* data, u32 index, u32 handle, u64* size) {
+    install_cias_data* installData = (install_cias_data*) data;
+
+    file_info* info = (file_info*) ((list_item*) linked_list_get(&installData->contents, index))->data;
+
+    if (info->ciaInfo.isZ3DS) {
+        return Z3DS_GetUncompressedSize((Z3DS_FILE*)handle, size);
+    } else {
+        return FSFILE_GetSize(handle, size);
+    }
 }
 
-static Result action_install_cias_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
-    return FSFILE_Read(handle, bytesRead, offset, buffer, size);
+static Result action_install_cias_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+    install_cias_data* installData = (install_cias_data*) data;
+
+    file_info* info = (file_info*) ((list_item*) linked_list_get(&installData->contents, index))->data;
+
+    if (info->ciaInfo.isZ3DS) {
+        return Z3DS_Read((Z3DS_FILE*)handle, bytesRead, offset, buffer, size);
+    } else {
+        return FSFILE_Read(handle, bytesRead, offset, buffer, size);
+    }
 }
 
 static Result action_install_cias_open_dst(void* data, u32 index, void* initialReadBlock, u64 size, u32* handle) {

--- a/source/fbi/action/installtickets.c
+++ b/source/fbi/action/installtickets.c
@@ -95,11 +95,11 @@ static Result action_install_tickets_close_src(void* data, u32 index, bool succe
     return res;
 }
 
-static Result action_install_tickets_get_src_size(void* data, u32 handle, u64* size) {
+static Result action_install_tickets_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     return FSFILE_GetSize(handle, size);
 }
 
-static Result action_install_tickets_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result action_install_tickets_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     return FSFILE_Read(handle, bytesRead, offset, buffer, size);
 }
 

--- a/source/fbi/action/pastecontents.c
+++ b/source/fbi/action/pastecontents.c
@@ -119,11 +119,11 @@ static Result action_paste_contents_close_src(void* data, u32 index, bool succee
     return FSFILE_Close(handle);
 }
 
-static Result action_paste_contents_get_src_size(void* data, u32 handle, u64* size) {
+static Result action_paste_contents_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     return FSFILE_GetSize(handle, size);
 }
 
-static Result action_paste_contents_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result action_paste_contents_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     return FSFILE_Read(handle, bytesRead, offset, buffer, size);
 }
 

--- a/source/fbi/dumpnand.c
+++ b/source/fbi/dumpnand.c
@@ -27,11 +27,11 @@ static Result dumpnand_close_src(void* data, u32 index, bool succeeded, u32 hand
     return FSFILE_Close(handle);
 }
 
-static Result dumpnand_get_src_size(void* data, u32 handle, u64* size) {
+static Result dumpnand_get_src_size(void* data, u32 index, u32 handle, u64* size) {
     return FSFILE_GetSize(handle, size);
 }
 
-static Result dumpnand_read_src(void* data, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
+static Result dumpnand_read_src(void* data, u32 index, u32 handle, u32* bytesRead, void* buffer, u64 offset, u32 size) {
     return FSFILE_Read(handle, bytesRead, offset, buffer, size);
 }
 

--- a/source/fbi/task/listfiles.c
+++ b/source/fbi/task/listfiles.c
@@ -49,20 +49,40 @@ static void task_populate_files_retrieve_meta(file_info* fileInfo) {
             FSFILE_GetSize(fileHandle, &fileInfo->size);
 
             if(fileInfo->isCia) {
+                bool isZ3DS = Z3DS_IsFile(fileHandle, "CIA", 3);
+                Z3DS_FILE* zfile = NULL;
+                if (isZ3DS) {
+                    zfile = Z3DS_Create(fileHandle);
+                }
+
                 AM_TitleEntry titleEntry;
-                if(R_SUCCEEDED(AM_GetCiaFileInfo(MEDIATYPE_SD, &titleEntry, fileHandle))) {
+                Result res = 0;
+                if (isZ3DS) {
+                    Z3DS_Metadata_Item item = Z3DS_GetMetadataItem(zfile, "titleinfo");
+                    if (!item.found || item.size != sizeof(AM_TitleEntry)) {
+                        res = R_APP_BAD_DATA;
+                    } else {
+                        memcpy(&titleEntry, item.value, sizeof(AM_TitleEntry));
+                    }
+                } else {
+                    res = AM_GetCiaFileInfo(MEDIATYPE_SD, &titleEntry, fileHandle);
+                }
+
+                if(R_SUCCEEDED(res)) {
+                    fileInfo->ciaInfo.isZ3DS = isZ3DS;
                     fileInfo->ciaInfo.titleId = titleEntry.titleID;
                     fileInfo->ciaInfo.version = titleEntry.version;
                     fileInfo->ciaInfo.installedSize = titleEntry.size;
                     fileInfo->ciaInfo.hasMeta = false;
+                    fileInfo->ciaInfo.installedSizeAprox = isZ3DS;
 
-                    if(fs_get_title_destination(titleEntry.titleID) != MEDIATYPE_SD && R_SUCCEEDED(AM_GetCiaFileInfo(MEDIATYPE_NAND, &titleEntry, fileHandle))) {
+                    if(!isZ3DS && fs_get_title_destination(titleEntry.titleID) != MEDIATYPE_SD && R_SUCCEEDED(AM_GetCiaFileInfo(MEDIATYPE_NAND, &titleEntry, fileHandle))) {
                         fileInfo->ciaInfo.installedSize = titleEntry.size;
                     }
 
                     SMDH* smdh = (SMDH*) calloc(1, sizeof(SMDH));
                     if(smdh != NULL) {
-                        if(R_SUCCEEDED(cia_file_get_smdh(smdh, fileHandle))) {
+                        if(R_SUCCEEDED(cia_file_get_smdh(smdh, fileHandle, zfile))) {
                             if(smdh->magic[0] == 'S' && smdh->magic[1] == 'M' && smdh->magic[2] == 'D' && smdh->magic[3] == 'H') {
                                 SMDH_title* smdhTitle = smdh_select_title(smdh);
 
@@ -82,6 +102,9 @@ static void task_populate_files_retrieve_meta(file_info* fileInfo) {
                     fileInfo->ciaInfo.loaded = true;
                 } else {
                     fileInfo->isCia = false;
+                }
+                if (isZ3DS) {
+                    Z3DS_Free(zfile, false);
                 }
             } else if(fileInfo->isTicket) {
                 u32 bytesRead = 0;

--- a/source/fbi/task/listfiles.h
+++ b/source/fbi/task/listfiles.h
@@ -10,10 +10,12 @@ typedef struct list_item_s list_item;
 
 typedef struct cia_info_s {
     bool loaded;
+    bool isZ3DS;
 
     u64 titleId;
     u16 version;
     u64 installedSize;
+    bool installedSizeAprox;
     bool hasMeta;
     meta_info meta;
 } cia_info;

--- a/source/fbi/task/uitask.c
+++ b/source/fbi/task/uitask.c
@@ -153,10 +153,10 @@ void task_draw_file_info(ui_view* view, void* data, float x1, float y1, float x2
                                     "Title ID: %016llX\n"
                                             "Version: %hu (%d.%d.%d)\n"
                                             "Region: %s\n"
-                                            "Installed Size: %.2f %s",
+                                            "Installed Size: %s%.2f %s",
                                     info->ciaInfo.titleId,
                                     info->ciaInfo.version, (info->ciaInfo.version >> 10) & 0x3F, (info->ciaInfo.version >> 4) & 0x3F, info->ciaInfo.version & 0xF,
-                                    regionString,
+                                    regionString, info->ciaInfo.installedSizeAprox ? "approx. " : "",
                                     ui_get_display_size(info->ciaInfo.installedSize),
                                     ui_get_display_size_units(info->ciaInfo.installedSize));
         } else if(info->isTicket && info->ticketInfo.loaded) {


### PR DESCRIPTION
Adds support for installing zcia files. This files are compressed using zstd, which achieves a 20% average file compression (depends on the game/application). Install speed seems to be around 1.5MB/sec on my device (non-compressed is around 1.8MB/s).

So far only [Azahar can compress cia files to zcia](https://github.com/azahar-emu/azahar/pull/1208)

The zstd library had to be added as a submodule in order to allow using the seekable format. While a 3ds portlib is provided by devKitPro, it lacks seekable support.

Remote zcia install will be implemented in a different PR.

